### PR TITLE
Optimized style

### DIFF
--- a/themes/OpenSouceWin/source/css/index.css
+++ b/themes/OpenSouceWin/source/css/index.css
@@ -152,7 +152,7 @@ a {
 .thumbnail2 {
   flex: none;
   width: 350px;
-  height: auto;
+  height: 100%;
   background: #d8d8d8;
   margin-right: 62px;
 }
@@ -161,6 +161,9 @@ a {
   margin-top: 30px;
   font-size: 16px;
   color: #3a3a3a;
+}
+.detail-right2 a {
+  color: #33a3dc;
 }
 .nick2 {
   font-size: 24px;


### PR DESCRIPTION
简介太长的话，会导致头像被拉伸。

修复简介中的a链接是白色，导致看不见。